### PR TITLE
Load kid body model when age='kid' is provided

### DIFF
--- a/smplx/body_models.py
+++ b/smplx/body_models.py
@@ -506,7 +506,7 @@ class SMPLH(SMPL):
 
     def __init__(
         self, model_path,
-        kid_template_path,
+        kid_template_path = '',
         data_struct: Optional[Struct] = None,
         create_left_hand_pose: bool = True,
         left_hand_pose: Optional[Tensor] = None,

--- a/smplx/body_models.py
+++ b/smplx/body_models.py
@@ -506,7 +506,7 @@ class SMPLH(SMPL):
 
     def __init__(
         self, model_path,
-        kid_template_path = '',
+        kid_template_path: str = '',
         data_struct: Optional[Struct] = None,
         create_left_hand_pose: bool = True,
         left_hand_pose: Optional[Tensor] = None,

--- a/smplx/body_models.py
+++ b/smplx/body_models.py
@@ -140,21 +140,20 @@ class SMPL(nn.Module):
 
         super(SMPL, self).__init__()
         self.batch_size = batch_size
-       	shapedirs = data_struct.shapedirs
+        shapedirs = data_struct.shapedirs
+        if (shapedirs.shape[-1] < self.SHAPE_SPACE_DIM):
+            print(f'WARNING: You are using a {self.name()} model, with only'
+                  ' 10 shape coefficients.')
+            num_betas = min(num_betas, 10)
+        else:
+            num_betas = min(num_betas, self.SHAPE_SPACE_DIM)
+
         if self.age=='kid':
             v_template_smil = np.load(kid_template_path)
             v_template_smil -= np.mean(v_template_smil, axis=0)
-            v_template_smil = np.expand_dims(v_template_smil,axis=2)
-            v_template_diff = v_template_smil - np.expand_dims(data_struct.v_template,axis=2)
-            shapedirs = np.concatenate((shapedirs[:,:,:num_betas],v_template_diff),axis=2)
-            num_betas=num_betas+1
-        else:
-            if (shapedirs.shape[-1] < self.SHAPE_SPACE_DIM):
-                print(f'WARNING: You are using a {self.name()} model, with only'
-                ' 10 shape coefficients.')
-                num_betas = min(num_betas, 10)  
-            else:
-                num_betas = min(num_betas, self.SHAPE_SPACE_DIM)
+            v_template_diff = np.expand_dims(v_template_smil - data_struct.v_template, axis=2)
+            shapedirs = np.concatenate((shapedirs[:, :, :num_betas], v_template_diff), axis=2)
+            num_betas = num_betas + 1
 
         self._num_betas = num_betas
         shapedirs = shapedirs[:, :, :num_betas]

--- a/smplx/body_models.py
+++ b/smplx/body_models.py
@@ -49,6 +49,7 @@ class SMPL(nn.Module):
 
     def __init__(
         self, model_path: str,
+	kid_template_path: str = '',
         data_struct: Optional[Struct] = None,
         create_betas: bool = True,
         betas: Optional[Tensor] = None,
@@ -63,6 +64,7 @@ class SMPL(nn.Module):
         batch_size: int = 1,
         joint_mapper=None,
         gender: str = 'neutral',
+        age: str = 'adult',
         vertex_ids: Dict[str, int] = None,
         v_template: Optional[Union[Tensor, Array]] = None,
         **kwargs
@@ -121,6 +123,7 @@ class SMPL(nn.Module):
         '''
 
         self.gender = gender
+        self.age = age
 
         if data_struct is None:
             if osp.isdir(model_path):
@@ -137,13 +140,21 @@ class SMPL(nn.Module):
 
         super(SMPL, self).__init__()
         self.batch_size = batch_size
-        shapedirs = data_struct.shapedirs
-        if (shapedirs.shape[-1] < self.SHAPE_SPACE_DIM):
-            print(f'WARNING: You are using a {self.name()} model, with only'
-                  ' 10 shape coefficients.')
-            num_betas = min(num_betas, 10)
+       	shapedirs = data_struct.shapedirs
+        if self.age=='kid':
+            v_template_smil = np.load(kid_template_path)
+            v_template_smil -= np.mean(v_template_smil, axis=0)
+            v_template_smil = np.expand_dims(v_template_smil,axis=2)
+            v_template_diff = v_template_smil - np.expand_dims(data_struct.v_template,axis=2)
+            shapedirs = np.concatenate((shapedirs[:,:,:num_betas],v_template_diff),axis=2)
+            num_betas=num_betas+1
         else:
-            num_betas = min(num_betas, self.SHAPE_SPACE_DIM)
+            if (shapedirs.shape[-1] < self.SHAPE_SPACE_DIM):
+                print(f'WARNING: You are using a {self.name()} model, with only'
+                ' 10 shape coefficients.')
+                num_betas = min(num_betas, 10)  
+            else:
+                num_betas = min(num_betas, self.SHAPE_SPACE_DIM)
 
         self._num_betas = num_betas
         shapedirs = shapedirs[:, :, :num_betas]
@@ -496,6 +507,7 @@ class SMPLH(SMPL):
 
     def __init__(
         self, model_path,
+        kid_template_path,
         data_struct: Optional[Struct] = None,
         create_left_hand_pose: bool = True,
         left_hand_pose: Optional[Tensor] = None,
@@ -506,6 +518,7 @@ class SMPLH(SMPL):
         flat_hand_mean: bool = False,
         batch_size: int = 1,
         gender: str = 'neutral',
+        age: str = 'adult',
         dtype=torch.float32,
         vertex_ids=None,
         use_compressed: bool = True,
@@ -578,8 +591,9 @@ class SMPLH(SMPL):
 
         super(SMPLH, self).__init__(
             model_path=model_path,
+            kid_template_path=kid_template_path,
             data_struct=data_struct,
-            batch_size=batch_size, vertex_ids=vertex_ids, gender=gender,
+            batch_size=batch_size, vertex_ids=vertex_ids, gender=gender, age=age,
             use_compressed=use_compressed, dtype=dtype, ext=ext, **kwargs)
 
         self.use_pca = use_pca
@@ -886,6 +900,7 @@ class SMPLX(SMPLH):
 
     def __init__(
         self, model_path: str,
+	kid_template_path: str = '',
         num_expression_coeffs: int = 10,
         create_expression: bool = True,
         expression: Optional[Tensor] = None,
@@ -898,6 +913,7 @@ class SMPLX(SMPLH):
         use_face_contour: bool = False,
         batch_size: int = 1,
         gender: str = 'neutral',
+        age: str = 'adult',
         dtype=torch.float32,
         ext: str = 'npz',
         **kwargs
@@ -967,11 +983,12 @@ class SMPLX(SMPLH):
 
         super(SMPLX, self).__init__(
             model_path=model_path,
+            kid_template_path=kid_template_path,
             data_struct=data_struct,
             dtype=dtype,
             batch_size=batch_size,
             vertex_ids=VERTEX_IDS['smplx'],
-            gender=gender, ext=ext,
+            gender=gender, age=age, ext=ext,
             **kwargs)
 
         lmk_faces_idx = data_struct.lmk_faces_idx


### PR DESCRIPTION
Added functionality to generate kid body model. If age flag is set to
kid, an extra shape parameter i.e. interpolation of SMIL-X and SMPL-X
template is added. One needs to provide the path to the SMIL/SMIL-X
template for this.