### PR TITLE
Fixed bug in output pkl when batch_size is larger than 1

### DIFF
--- a/transfer_model/__main__.py
+++ b/transfer_model/__main__.py
@@ -87,11 +87,11 @@ def main() -> None:
 
         for ii, path in enumerate(paths):
             _, fname = osp.split(path)
-
-            output_path = osp.join(
-                output_folder, f'{osp.splitext(fname)[0]}.pkl')
-            with open(output_path, 'wb') as f:
-                pickle.dump(var_dict, f)
+            if ii == 0:
+                output_path = osp.join(
+                    output_folder, f'{osp.splitext(fname)[0]}.pkl')
+                with open(output_path, 'wb') as f:
+                    pickle.dump(var_dict, f)
 
             output_path = osp.join(
                 output_folder, f'{osp.splitext(fname)[0]}.obj')


### PR DESCRIPTION
As described in issue [#190](https://github.com/vchoutas/smplx/issues/190#issuecomment-2101219854), when `batch_size` is set to larger than 1, the same pkl file will be written multiple times. In the subsequent merge step, the resulting merged file will have `frame_no`*`batch_size` number of frames. 