### PR TITLE
Update default ext from npz to pkl in body_model_defaults.py

### DIFF
--- a/transfer_model/config/body_model_defaults.py
+++ b/transfer_model/config/body_model_defaults.py
@@ -89,7 +89,7 @@ class BodyModelConfig:
     folder: str = 'models'
     gender: str = 'neutral'
     extra_joint_path: str = ''
-    ext: str = 'npz'
+    ext: str = 'pkl'
 
     num_expression_coeffs: int = 10
 

--- a/transfer_model/transfer_model.py
+++ b/transfer_model/transfer_model.py
@@ -342,8 +342,8 @@ def run_fitting(
                  interactive=interactive,
                  **optim_cfg)
 
-    if 'translation' in var_dict:
-        optimizer_dict = build_optimizer([var_dict['translation']], optim_cfg)
+    if 'transl' in var_dict:
+        optimizer_dict = build_optimizer([var_dict['transl']], optim_cfg)
         closure = build_vertex_closure(
             body_model, var_dict,
             optimizer_dict,
@@ -351,12 +351,12 @@ def run_fitting(
             vertex_loss=vertex_loss,
             mask_ids=mask_ids,
             per_part=False,
-            params_to_opt=[var_dict['translation']],
+            params_to_opt=[var_dict['transl']],
         )
         # Optimize translation
         minimize(optimizer_dict['optimizer'],
                  closure,
-                 params=[var_dict['translation']],
+                 params=[var_dict['transl']],
                  summary_closure=log_closure,
                  summary_steps=summary_steps,
                  interactive=interactive,


### PR DESCRIPTION
The current transfer model script requires .npz model file instead of pkl. Updating this to reflect current file ext as described in the readme.